### PR TITLE
Make Apple Validator hit production then sandbox

### DIFF
--- a/appstore/validator.go
+++ b/appstore/validator.go
@@ -19,9 +19,8 @@ const (
 
 // Config is a configuration to initialize client
 type Config struct {
-	IsProduction  bool
-	TryBothStores bool
-	TimeOut       time.Duration
+	IsProduction bool
+	TimeOut      time.Duration
 }
 
 // IAPClient is an interface to call validation API in App Store
@@ -31,9 +30,8 @@ type IAPClient interface {
 
 // Client implements IAPClient
 type Client struct {
-	URL           string
-	TimeOut       time.Duration
-	TryBothStores bool
+	URL     string
+	TimeOut time.Duration
 }
 
 // HandleError returns error message by status code
@@ -98,11 +96,10 @@ func NewWithConfig(config Config) Client {
 	}
 
 	client := Client{
-		URL:           SandboxURL,
-		TimeOut:       config.TimeOut,
-		TryBothStores: config.TryBothStores,
+		URL:     SandboxURL,
+		TimeOut: config.TimeOut,
 	}
-	if config.IsProduction || config.TryBothStores {
+	if config.IsProduction {
 		client.URL = ProductionURL
 	}
 
@@ -131,7 +128,7 @@ func (c *Client) Verify(req IAPRequest, result interface{}) error {
 
 	r := &IAPResponse{}
 	err = json.Unmarshal(bodyBytes, r)
-	if c.TryBothStores && c.URL == ProductionURL && err == nil && r.Status == 21007 {
+	if err == nil && r.Status == 21007 {
 		c.URL = SandboxURL
 		err = c.Verify(req, result)
 		c.URL = ProductionURL

--- a/appstore/validator.go
+++ b/appstore/validator.go
@@ -127,7 +127,7 @@ func (c *Client) Verify(req IAPRequest, result interface{}) error {
 	err = json.NewDecoder(resp.Body).Decode(result)
 	if err == nil && c.TryBothStores && result.(IAPResponse).Status == 21007 {
 		c.URL = SandboxURL
-		c.Verify(req, result)
+		err = c.Verify(req, result)
 		c.URL = ProductionURL
 	}
 

--- a/appstore/validator.go
+++ b/appstore/validator.go
@@ -129,14 +129,12 @@ func (c *Client) Verify(req IAPRequest, result interface{}) error {
 		return err
 	}
 
-	if c.TryBothStores && c.URL == ProductionURL {
-		r := &IAPResponse{}
-		err = json.Unmarshal(bodyBytes, r)
-		if err == nil && r.Status == 21007 {
-			c.URL = SandboxURL
-			err = c.Verify(req, result)
-			c.URL = ProductionURL
-		}
+	r := &IAPResponse{}
+	err = json.Unmarshal(bodyBytes, r)
+	if c.TryBothStores && c.URL == ProductionURL && err == nil && r.Status == 21007 {
+		c.URL = SandboxURL
+		err = c.Verify(req, result)
+		c.URL = ProductionURL
 	} else {
 		err = json.Unmarshal(bodyBytes, result)
 	}

--- a/appstore/validator.go
+++ b/appstore/validator.go
@@ -81,9 +81,8 @@ func HandleError(status int) error {
 // New creates a client object
 func New() Client {
 	client := Client{
-		URL:           SandboxURL,
-		TimeOut:       time.Second * 5,
-		TryBothStores: false,
+		URL:     SandboxURL,
+		TimeOut: time.Second * 5,
 	}
 	if os.Getenv("IAP_ENVIRONMENT") == "production" {
 		client.URL = ProductionURL
@@ -125,7 +124,7 @@ func (c *Client) Verify(req IAPRequest, result interface{}) error {
 	defer resp.Body.Close()
 
 	err = json.NewDecoder(resp.Body).Decode(result)
-	if err == nil && c.TryBothStores && result.(IAPResponse).Status == 21007 {
+	if c.TryBothStores && err == nil && result.(IAPResponse).Status == 21007 {
 		c.URL = SandboxURL
 		err = c.Verify(req, result)
 		c.URL = ProductionURL

--- a/appstore/validator_test.go
+++ b/appstore/validator_test.go
@@ -149,27 +149,9 @@ func TestNewWithConfigTimeout(t *testing.T) {
 	}
 }
 
-func TestNewWithConfigTryBothStores(t *testing.T) {
-	config := Config{
-		TryBothStores: true,
-	}
-
-	expected := Client{
-		URL:           ProductionURL,
-		TimeOut:       time.Second * 5,
-		TryBothStores: true,
-	}
-
-	actual := NewWithConfig(config)
-	if !reflect.DeepEqual(actual, expected) {
-		t.Errorf("got %v\nwant %v", actual, expected)
-	}
-}
-
 func TestVerify(t *testing.T) {
 	client := New()
 	client.TimeOut = time.Millisecond * 100
-	client.TryBothStores = true
 
 	req := IAPRequest{
 		ReceiptData: "dummy data",

--- a/appstore/validator_test.go
+++ b/appstore/validator_test.go
@@ -91,7 +91,7 @@ func TestHandleError(t *testing.T) {
 
 func TestNew(t *testing.T) {
 	expected := Client{
-		URL:     "https://sandbox.itunes.apple.com/verifyReceipt",
+		URL:     SandboxURL,
 		TimeOut: time.Second * 5,
 	}
 
@@ -103,7 +103,7 @@ func TestNew(t *testing.T) {
 
 func TestNewWithEnvironment(t *testing.T) {
 	expected := Client{
-		URL:     "https://buy.itunes.apple.com/verifyReceipt",
+		URL:     ProductionURL,
 		TimeOut: time.Second * 5,
 	}
 
@@ -123,7 +123,7 @@ func TestNewWithConfig(t *testing.T) {
 	}
 
 	expected := Client{
-		URL:     "https://buy.itunes.apple.com/verifyReceipt",
+		URL:     ProductionURL,
 		TimeOut: time.Second * 2,
 	}
 
@@ -139,8 +139,25 @@ func TestNewWithConfigTimeout(t *testing.T) {
 	}
 
 	expected := Client{
-		URL:     "https://buy.itunes.apple.com/verifyReceipt",
+		URL:     ProductionURL,
 		TimeOut: time.Second * 5,
+	}
+
+	actual := NewWithConfig(config)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("got %v\nwant %v", actual, expected)
+	}
+}
+
+func TestNewWithConfigTryBothStores(t *testing.T) {
+	config := Config{
+		TryBothStores: true,
+	}
+
+	expected := Client{
+		URL:           ProductionURL,
+		TimeOut:       time.Second * 5,
+		TryBothStores: true,
 	}
 
 	actual := NewWithConfig(config)

--- a/appstore/validator_test.go
+++ b/appstore/validator_test.go
@@ -169,6 +169,7 @@ func TestNewWithConfigTryBothStores(t *testing.T) {
 func TestVerify(t *testing.T) {
 	client := New()
 	client.TimeOut = time.Millisecond * 100
+	client.TryBothStores = true
 
 	req := IAPRequest{
 		ReceiptData: "dummy data",


### PR DESCRIPTION
Call Production App Store First. Then call sandbox. We're currently
doing this outside of the library which isn't ideal.
https://developer.apple.com/library/content/technotes/tn2259/_index.html

How do I verify my receipt (iOS)?

Always verify your receipt first with the production URL; proceed to
verify with the sandbox URL if you receive a 21007 status code.
Following this approach ensures that you do not have to switch between
URLs while your application is being tested or reviewed in the sandbox
or is live in the App Store.

PLAT-6523